### PR TITLE
Fix 12 skipped ComboBox unit tests

### DIFF
--- a/src/components/ComboBox.tsx
+++ b/src/components/ComboBox.tsx
@@ -392,16 +392,25 @@ export const UIForgeComboBox: React.FC<UIForgeComboBoxProps> = ({
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
+  // Determine effective options: when a search/filter is active use filtered results
+  // (even if empty) so the "no options" message can be displayed; otherwise fall back
+  // to the full static options list.
+  const effectiveOptions = useMemo(() => {
+    const isFiltering = searchText.trim().length > 0
+    if (isFiltering) return filteredOptions
+    return filteredOptions.length > 0 ? filteredOptions : options
+  }, [filteredOptions, options, searchText])
+
   // Flatten current options for keyboard navigation
   const flatOptions = useMemo(() => {
-    const opts = flattenOptions(filteredOptions.length > 0 ? filteredOptions : options)
+    const opts = flattenOptions(effectiveOptions)
     return opts.filter((opt) => !opt.disabled)
-  }, [filteredOptions, options, flattenOptions])
+  }, [effectiveOptions, flattenOptions])
 
   // Memoize flattened options for rendering (includes disabled options)
   const flatOptionsForRender = useMemo(() => {
-    return flattenOptions(filteredOptions.length > 0 ? filteredOptions : options)
-  }, [filteredOptions, options, flattenOptions])
+    return flattenOptions(effectiveOptions)
+  }, [effectiveOptions, flattenOptions])
 
   // Create index mapping for performance in render loop
   const optionIndexMap = useMemo(() => {
@@ -584,6 +593,7 @@ export const UIForgeComboBox: React.FC<UIForgeComboBoxProps> = ({
             className={`${baseClass}-input`}
             value={searchText}
             onChange={handleInputChange}
+            onClick={(e) => e.stopPropagation()}
             placeholder={placeholder}
             disabled={disabled}
             aria-autocomplete="list"


### PR DESCRIPTION
## Summary
- Fixed test interactions for searchable ComboBox dropdown
- Unskipped 12 tests (4 search/filter + 8 async search)
- All 651 tests now pass (was 639 passed, 12 skipped)

## Root Causes

Three issues prevented the tests from working:

1. **Click propagation bug in component**: Clicking the search `<input>` inside the control div bubbled up to `handleToggle`, immediately closing the dropdown. Fixed by adding `onClick={(e) => e.stopPropagation()}` on the input element.

2. **Incorrect dropdown open method in tests**: Skipped tests used `fireEvent.keyDown(combobox, { key: 'ArrowDown' })` which doesn't focus the element first. Fixed by using the same pattern as passing tests: `combobox.focus()` + `await user.keyboard('{ArrowDown}')`.

3. **Async state updates outside `act()`**: The component's debounced `setTimeout` callback performs React state updates (`setFilteredOptions`, `setAsyncLoading`) that need to be flushed inside `act()`. Added a `flushDebounce()` helper that wraps the wait in `act()`.

4. **Empty filter fallback bug in component**: When `searchText` produced zero matches, `flatOptions` fell back to showing all original options (due to `filteredOptions.length > 0 ? filteredOptions : options`), making `noOptionsMessage` unreachable. Fixed by checking `searchText.trim().length > 0` to use filtered results even when empty.

## Component Changes (genuine bugs)
- `ComboBox.tsx`: Added `onClick stopPropagation` on search input to prevent toggle
- `ComboBox.tsx`: Fixed `effectiveOptions` logic so empty filter results show "no options" message

Fixes #84